### PR TITLE
Fix: Remove conditional steps in Poetry install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,13 @@
 # GitHub Action - Setup and Cache Python Poetry
 
 
-This action installs Poetry via [`snok/install-poetry`](https://github.com/snok/install-poetry), provides caching for both the poetry binary, installs dependencies based on your `pyproject.toml` and `poetry.lock` and caches the dependencies.
+This action installs Poetry via [`snok/install-poetry`](https://github.com/snok/install-poetry), and also provides caching for the Poetry binary and your dependencies.
 
 ## Cache Creation
 When is the cache populated?
 
 * **Poetry binary**<br/>The change of runner OS, Python version, and Poetry version have changed. It will create multiple caches if you are using a matrix strategy.
-* **Dependencies**<br/>The change of runner OS, Python version. If you change the content of `poetry.lock`, Actions will still download the cache folder, run the `poetry install`, and then save it to the cache server. It will also create multiple caches if you are using a matrix strategy.
-
-
-## Improvements
-
-1. Comparison with `snok/install-poetry` 
-    * Usually takes ~10 seconds
-    * Cache poetry binary and it will take around 2-4 seconds
-1. Setup python + install poetry + install dependencies (list below) 
-    * Usually takes ~34 seconds 
-    * Cache dependencies only will take 13-14 seconds
-    * Cache poetry and dependencies will take 3-4 seconds 
-
-**Note:** If you have more dependencies, GitHub Action will take more time to download from the cache server. Still, it's usually significantly faster than downloading and installing it for every job and workflow.
+* **Dependencies**<br/>The change of runner OS, Python version. If you change the content of `poetry.lock`, this Action will still download the cache folder, run the `poetry install`, and then save it to the cache server. It will also create multiple caches if you are using a matrix strategy.
 
 ## How to Use
 
@@ -46,9 +33,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      #----------------------------------------------
-      # Check out repo and set up python
-      #----------------------------------------------
+      #------------------------------------
+      #  Check out repo and set up python
+      #------------------------------------
       - name: Check out the repository
         uses: actions/checkout@v3
       - name: "Setup Python, Poetry and Dependencies"
@@ -57,9 +44,9 @@ jobs:
           python-version: 3.8
           poetry-version: 1.2.2
 
-      #----------------------------------------------
-      #    Run Your Actual Job
-      #----------------------------------------------
+      #------------------------------------
+      #  Run Your Actual Job
+      #------------------------------------
       - name: Run tests
         run: |
           poetry run pytest
@@ -86,9 +73,9 @@ jobs:
         poetry-version: [1.2.2]
     runs-on: ubuntu-latest
     steps:
-      #----------------------------------------------
-      # Check out repo and set up python
-      #----------------------------------------------
+      #------------------------------------
+      #  Check out repo and set up python
+      #------------------------------------
       - name: Check out the repository
         uses: actions/checkout@v3
       - name: "Setup Python, Poetry and Dependencies"
@@ -97,9 +84,9 @@ jobs:
           python-version: ${{matrix.python-version}}
           poetry-version: ${{matrix.poetry-version}}
 
-      #----------------------------------------------
-      #    Run Your Actual Job
-      #----------------------------------------------
+      #------------------------------------
+      #  Run Your Actual Job
+      #------------------------------------
       - name: Run tests
         run: |
           poetry run pytest

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,6 @@ runs:
         path: ~/.local
         key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ inputs.poetry-version }}
     - name: Install Poetry
-      if: steps.cached-poetry-binary.outputs.cache-hit != 'true'
       uses: snok/install-poetry@v1
       with:
         version: ${{ inputs.poetry-version }}

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Setup and Cache Python Poetry"
-description: "Python Poetry setup, including the caching of dependencies and Poetry install."
+description: "Python Poetry setup, including the caching of dependencies."
 branding:
   icon: 'play'
   color: 'blue'

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Setup and Cache Python Poetry"
-description: "Python Poetry setup, including the caching of dependencies."
+description: "Python Poetry setup, including the caching of dependencies and Poetry installation."
 branding:
   icon: 'play'
   color: 'blue'
@@ -15,17 +15,17 @@ inputs:
 runs:
   using: "composite"
   steps:
-    #----------------------------------------------
-    #       Set-up python
-    #----------------------------------------------
+    #---------------------------#
+    #       Set-up python       #
+    #---------------------------#
     - name: Set up python ${{ inputs.python-version }}
       id: setup-python
       uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
-    #----------------------------------------------
-    #  -----  install & configure poetry  -----
-    #----------------------------------------------
+    #----------------------------------------#
+    #       Install & configure Poetry       #            
+    #----------------------------------------#
     - name: Load cached Poetry Binary
       id: cached-poetry-binary
       uses: actions/cache@v3
@@ -38,9 +38,9 @@ runs:
         version: ${{ inputs.poetry-version }}
         virtualenvs-create: true
         virtualenvs-in-project: true
-    #----------------------------------------------
-    #       load cached venv if cache exists
-    #----------------------------------------------
+    #----------------------------------------------#
+    #       Load cached venv if cache exists       #      
+    #----------------------------------------------#
     - name: Load cached venv
       id: cached-poetry-dependencies
       uses: actions/cache@v3
@@ -51,9 +51,9 @@ runs:
         # Note cache-hit returns false in this case, so the below step will run
         restore-keys: |
           venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-
-    #----------------------------------------------
-    # install dependencies if cache does not exist
-    #----------------------------------------------
+    #----------------------------------------------------------#
+    #       Install dependencies if cache does not exist       #
+    #----------------------------------------------------------#
     - name: Install dependencies
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
       shell: bash


### PR DESCRIPTION
There is no need to set a conditional for whether to restore the Poetry binary cache. Also this appears to create issues when running with self-hosted runners. Therefore this PR looks to remove this condition.