### PR TITLE
Pass extra arguments to poetry install

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ jobs:
           poetry run pytest
 ```
 
+## Advanced usage
+
+### Passing extra arguments to `poetry install`
+
+By default the action will install your dendencies with `poetry install --no-interaction --no-root` You can specify extra arguments with `install-args`, e.g.
+
+```yml
+      - name: "Setup Python, Poetry and Dependencies"
+        uses: packetcoders/action-setup-cache-python-poetry@main
+        with:
+          python-version: "3.12"
+          poetry-version: "1.6.1"
+          install-args: --all-extras
+```
+to install any optional dependencies alongside the required ones.
+
 ## License
 
 The scripts and documentation in this project are released under the [MIT License](LICENSE).

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   poetry-version:
     description: Poetry Version
     required: true
+  install-args:
+    description: Extra arguments to `poetry install`
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -46,7 +50,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}${{ inputs.install-args }}
         # Restore cache with this prefix if not exact match with key
         # Note cache-hit returns false in this case, so the below step will run
         restore-keys: |
@@ -57,4 +61,4 @@ runs:
     - name: Install dependencies
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
       shell: bash
-      run: poetry install --no-interaction --no-root
+      run: poetry install --no-interaction --no-root ${{ inputs.install-args }}


### PR DESCRIPTION
Some projects have optional dependencies that should be installed for full test coverage. This PR adds an option to pass extra arguments to `poetry install` to cover cases like this.